### PR TITLE
[feature] Env divided into env and agent

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,2 @@
+from .agents import EpsilonGreedyAgent, MachineAgent, UserAgent
+from .policies import *

--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -1,0 +1,93 @@
+import logging
+import random
+import numpy as np
+
+from .policies import DotsAndBoxesPolicy
+from src.dots_boxes import DotsAndBoxes, DotsAndBoxesState
+from src.learning_player import BoardSaver
+
+class MachineAgent:
+    def __init__(self, env:DotsAndBoxes, policy:DotsAndBoxesPolicy):
+        self._policy = policy
+        self._env = env
+    
+    def get_action(self, observations: DotsAndBoxesState):
+        return self._policy.next_action(observations, self._env.action_spaces)
+    
+    def update(self, *args, **kwargs):
+        pass
+
+    def update_value_function(self, Q: BoardSaver):
+        self._policy._q_value_function = Q.copy()
+
+class UserAgent:
+    def __init__(self, env: DotsAndBoxes):
+        self._env = env
+    
+    def get_action(self, observations: DotsAndBoxesState):
+        user_input = input(f'give two adjacent nodes in the format "0,0 0,1": ')
+        user_input = user_input.split(' ')
+        action = [(int(a.split(',')[0]), int(a.split(',')[1])) for a in user_input]
+        return action
+    
+    def update(self, *args, **kwargs):
+        pass
+
+class EpsilonGreedyAgent:
+    def __init__(self,
+                 env: DotsAndBoxes,
+                 policy: DotsAndBoxesPolicy,
+                 learning_rate: float,
+                 initial_epsilon: float,
+                 epsilon_decay: float,
+                 final_epsilon: float,
+                 gamma: float,
+                ):
+        self._learning_rate = learning_rate
+        self._policy = policy
+        self._env = env
+        self._initial_epsilon = initial_epsilon
+        self._epsilon_decay = epsilon_decay
+        self._final_epsilon = final_epsilon
+        self.epsilon = initial_epsilon
+        self._gamma = gamma
+        self.training_error = []
+
+
+    def get_action(self, observations: DotsAndBoxesState):
+        action_spaces = self._env.action_spaces
+        self.set_action_initial_value(observations, action_spaces)
+        
+        if np.random.random() < self.epsilon:
+            action = random.choices(list(action_spaces))[0]
+        else:
+            action = max(action_spaces, key=lambda a: self._policy._q_value_function.get(observations, a))
+        return action
+
+    def set_action_initial_value(self, observations: DotsAndBoxesState, action_spaces):
+        if not self._policy._q_value_function.contains(observations):
+            for a in action_spaces:
+                self._policy._q_value_function.define(observations, a, self._env.size)
+    
+    def update(
+    self,
+    state: DotsAndBoxesState,
+    action,
+    reward: float,
+    terminated: bool,
+    next_state: DotsAndBoxesState,
+    ):
+        """Updates the Q-value of an action."""
+        old_q_value = self._policy._q_value_function.get(state, action)
+        self.set_action_initial_value(next_state, self._env.action_spaces)
+        next_expected_value = (
+            max(map(lambda a: self._policy._q_value_function.get(next_state, a), self._env.action_spaces)) if next_state is not None and not terminated else 0
+        )
+        temporal_difference = reward + self._gamma * next_expected_value - old_q_value
+        new_q_value = old_q_value + self._learning_rate * temporal_difference
+        self._policy._q_value_function.define(state, action, new_q_value)
+        self.training_error.append(temporal_difference)
+        self.decay_epsilon()
+
+    def decay_epsilon(self):
+        self.epsilon = max(self._final_epsilon, self.epsilon - self._epsilon_decay)

--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -12,7 +12,7 @@ class MachineAgent:
         self._env = env
     
     def get_action(self, observations: DotsAndBoxesState):
-        return self._policy.next_action(observations, self._env.action_spaces)
+        return self._policy.next_action(observations, self._env.action_spaces), False
     
     def update(self, *args, **kwargs):
         pass
@@ -28,7 +28,7 @@ class UserAgent:
         user_input = input(f'give two adjacent nodes in the format "0,0 0,1": ')
         user_input = user_input.split(' ')
         action = [(int(a.split(',')[0]), int(a.split(',')[1])) for a in user_input]
-        return action
+        return action, False
     
     def update(self, *args, **kwargs):
         pass
@@ -56,18 +56,20 @@ class EpsilonGreedyAgent:
 
     def get_action(self, observations: DotsAndBoxesState):
         action_spaces = self._env.action_spaces
-        self.set_action_initial_value(observations, action_spaces)
+        new_state = self.set_action_initial_value(observations, action_spaces)
         
         if np.random.random() < self.epsilon:
             action = random.choices(list(action_spaces))[0]
         else:
             action = max(action_spaces, key=lambda a: self._policy._q_value_function.get(observations, a))
-        return action
+        return action, new_state
 
     def set_action_initial_value(self, observations: DotsAndBoxesState, action_spaces):
         if not self._policy._q_value_function.contains(observations):
             for a in action_spaces:
                 self._policy._q_value_function.define(observations, a, self._env.size)
+            return True
+        return False
     
     def update(
     self,

--- a/src/agents/policies/__init__.py
+++ b/src/agents/policies/__init__.py
@@ -1,0 +1,1 @@
+from .policies import DotsAndBoxesCloseBoxesPolicy, DotsAndBoxesMixerPolicy, DotsAndBoxesMaxIfKnownPolicy, DotsAndBoxesRandomPolicy, DotsAndBoxesPolicy

--- a/src/agents/policies/policies.py
+++ b/src/agents/policies/policies.py
@@ -1,0 +1,72 @@
+import random
+
+class DotsAndBoxesPolicy:
+    def __init__(self, q_value_function):
+        self._q_value_function = q_value_function
+
+    def next_action(self, state, action_space):
+        raise NotImplementedError()
+
+
+class DotsAndBoxesCloseBoxesPolicy(DotsAndBoxesPolicy):
+    """
+    Closes a box if possible, if not, returns a random choice of action space
+    """
+
+    def next_action(self, state, action_space):
+        max_width = max(map(lambda x: x[1][1], action_space))
+        max_height = max(map(lambda x: x[1][0], action_space))
+        for i in range(max_height):
+            for j in range(max_width):
+                borders = [
+                    ((i, j), (i, j + 1)),
+                    ((i, j), (i + 1, j)),
+                    ((i + 1, j), (i + 1, j + 1)),
+                    ((i, j + 1), (i + 1, j + 1)),
+                ]
+                # If there is a box with 3 sides closed, close the last one
+                if sum(1 for b in borders if b not in action_space) == 3:
+                    return next(b for b in borders if b in action_space)
+
+        return random.sample(sorted(action_space), 1)[0]
+
+
+class DotsAndBoxesRandomPolicy(DotsAndBoxesPolicy):
+    """
+    Returns a random choice of action space
+    """
+    def next_action(self, state, action_space):
+        return random.sample(sorted(action_space), 1)[0]
+
+
+class DotsAndBoxesMaxIfKnownPolicy(DotsAndBoxesPolicy):
+    """
+    Return an action with maximum reward if state is known.
+    Return a random action in other case.
+    """
+    def next_action(self, state, action_space):
+        if self._q_value_function.contains(state):
+            action = max(action_space, key=lambda a: self._q_value_function.get(state, a))
+        else:
+            action = random.sample(sorted(action_space), 1)[0]
+        return action
+
+class DotsAndBoxesMixerPolicy(DotsAndBoxesPolicy):
+    """
+    Return an action with maximum reward if state is known.
+    Return a random action in other case.
+    """
+    def __init__(self, q_value_function):
+        super().__init__(q_value_function)
+        self._greedy = DotsAndBoxesCloseBoxesPolicy(q_value_function=q_value_function)
+
+    def next_action(self, state, action_space):
+        
+        if self._q_value_function.contains(state):
+            action = max(action_space, key=lambda a: self._q_value_function.get(state, a))
+        else:
+            action = self._greedy.next_action(state, action_space)
+        return action
+
+    def update_q_value_function(self, q_value_function):
+        self._q_value_function = q_value_function

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,2 @@
+PLAYER_1 = 1
+PLAYER_2 = 2

--- a/src/learning_player.py
+++ b/src/learning_player.py
@@ -1,4 +1,3 @@
-import logging
 import bitstring as bitstring
 import itertools
 

--- a/src/learning_player.py
+++ b/src/learning_player.py
@@ -1,3 +1,4 @@
+import logging
 import bitstring as bitstring
 import itertools
 
@@ -248,7 +249,6 @@ class BoardSaver:
 
     def get(self, state: DotsAndBoxesState, action):
         _board, _action = self._equivalent_board_action(state.state, action)
-
         return self.boards[_board][state.player_points][_action]
 
     def define(self, state: DotsAndBoxesState, action, value):

--- a/src/main.py
+++ b/src/main.py
@@ -43,7 +43,7 @@ def q_learning(
             #average_new_states = sum((key*value for key, value in new_states.items())) / sum(new_states.values())
             average_amount_of_turns = sum((key*value for key, value in amount_of_turns.items())) / sum(amount_of_turns.values())
             logging.info(
-                f"episode: {e}, reward rate: {avg_rw:.2f}, avg_won: {avg_won:.2%}. avg_pd_aot {average_amount_of_turns:.2%}"
+                f"episode: {e}, reward rate: {avg_rw:.2f}, avg_won: {avg_won:.2%}. avg_pd_aot {average_amount_of_turns:.2f}"
             )
             
             

--- a/src/main.py
+++ b/src/main.py
@@ -6,157 +6,142 @@ import pickle
 import os.path
 from collections import defaultdict
 
-from learning_player import BoardSaver
-from dots_boxes import (
+from .learning_player import BoardSaver
+from .dots_boxes import (
     DotsAndBoxes,
-    DotsAndBoxesMaxIfKnownPolicy,
-    DotsAndBoxesRandomPolicy,
     DotsAndBoxesState,
-    DotsAndBoxesCloseBoxesPolicy,
-    DotsAndBoxesMixerPolicy
 )
+from .agents import MachineAgent, UserAgent, EpsilonGreedyAgent
+from .agents.policies import DotsAndBoxesCloseBoxesPolicy, DotsAndBoxesMixerPolicy
+
+from .constants import PLAYER_1, PLAYER_2
+
 import logging
 
 random.seed(0)
 
 
-def epsilon_greedy(Q, board: DotsAndBoxesState | None, action_spaces, epsilon):
-    if board is None:
-        return None
-
-    max_action = max(action_spaces, key=lambda a: Q.get(board, a))
-    probs = list(
-        map(
-            lambda x: 1 - epsilon + epsilon / len(action_spaces) if max_action == x else epsilon / len(action_spaces),
-            action_spaces,
-        )
-    )
-    return random.choices(list(action_spaces), probs).pop()
-
-[]
 def q_learning(
     env: DotsAndBoxes,
     num_episodes: int,
-    alpha: float,
-    gamma: float = 1.0,
-    eps: float = 1.0,
-    eps_decay: float = 0.9999,
-    epsmin: float = 0.01,
-    Q: BoardSaver = None,
-):
-    if Q is None:
-        Q = BoardSaver(env.size)
+    machine_agent: MachineAgent,
+    learning_agent: EpsilonGreedyAgent,
+) -> BoardSaver:
     rw = 0
     won = 0
-    new_states = defaultdict(int)
     amount_of_turns = defaultdict(int)
+    
     for e in range(num_episodes):
-        state = env.reset()
-        turn = 0
-        if not Q.contains(state):
-            for a in env.action_spaces:
-                Q.define(state, a, env.size)
-            new_states[turn] += 1
-
-        action = epsilon_greedy(Q, state, env.action_spaces, eps)
-        done = False
+        reward_game, won_game, turns = play_one_game(env, machine_agent, learning_agent)
+        rw += reward_game
+        won += won_game
+        amount_of_turns[turns] += 1
         
-        while not done:
-            next_state, info = env.step(action)
-            turn += 1
-            reward = info.get("reward")
-            done = info.get("done")
-            rw += reward
-
-            if done:
-                next_state = None
-                won += info.get("player_1_points") > info.get("player_2_points")
-
-            elif not Q.contains(next_state):
-                for a in env.action_spaces:
-                    Q.define(next_state, a, env.size)
-                new_states[turn] += 1
-            next_action = epsilon_greedy(Q, next_state, env.action_spaces, eps)
-
-            eps = max(epsmin, eps * eps_decay)
-
-            old_q_value = Q.get(state, action)
-            next_expected_value = (
-                max(map(lambda a: Q.get(next_state, a), env.action_spaces)) if next_state is not None else 0
-            )
-            new_q_value = old_q_value + alpha * (reward + gamma * next_expected_value - old_q_value)
-            Q.define(state, action, new_q_value)
-
-            state = next_state
-            action = next_action
-        amount_of_turns[turn] += 1
         if e % 100 == 0:
             avg_rw = rw / 100
             avg_won = won / 100
-            average_new_states = sum((key*value for key, value in new_states.items())) / sum(new_states.values())
+            #average_new_states = sum((key*value for key, value in new_states.items())) / sum(new_states.values())
             average_amount_of_turns = sum((key*value for key, value in amount_of_turns.items())) / sum(amount_of_turns.values())
             logging.info(
-                f"episode: {e}, reward rate: {avg_rw}, new states: {sum(new_states.values())}, epsilon: {eps}, avg_won: {avg_won}. avg_pd_ns {average_new_states}, avg_pd_aot {average_amount_of_turns}"
+                f"episode: {e}, reward rate: {avg_rw:.2f}, avg_won: {avg_won:.2%}. avg_pd_aot {average_amount_of_turns:.2%}"
             )
             
+            
+            if avg_won > 0.65:
+                logging.info(f"Update q value function: episode: {e}, reward rate: {avg_rw:.2f}, avg_won: {avg_won:.2%}. avg_pd_aot {average_amount_of_turns:.2%}")
+                machine_agent.update_value_function(learning_agent._policy._q_value_function)
+                q_file = f"q_value_function_{board_size}x{board_size}_epoch{e}.pickle"
+                save_value_function(q_file, learning_agent._policy._q_value_function)
             rw = 0
             won = 0
-            if avg_won > 0.65:
-                logging.info(f"Update q value function: episode: {e}, reward rate: {avg_rw}, new states: {sum(new_states.values())}, epsilon: {eps}, avg_won: {avg_won}. avg_pd_ns {average_new_states}, avg_pd_aot {average_amount_of_turns}")
-                env.update_q_value_function(q_value_function=Q)
-                q_file = f"q_value_function_{board_size}x{board_size}_epoch{e}.pickle"
-                save_value_function(q_file, Q)
-            new_states = defaultdict(int)
             amount_of_turns = defaultdict(int)
+
+    return learning_agent._policy._q_value_function
+
+def play_one_game(env: DotsAndBoxes, machine_agent, learning_agent, render=False):
+    state, info = env.reset()
+    turn = 0
+    rw = 0
+    done = False
     
-    return Q
-
-
-def play_against_player(board_size, q_value_function):
-    inp = ""
-    env = DotsAndBoxes(board_size, DotsAndBoxesMixerPolicy(q_value_function))
-    env.render()
-    while inp != "quit":
-        inp = sys.stdin.readline()
-
-        def splitter(n):
-            node = list(map(int, n.split(",")))
-            return node[0], node[1]
-
-        action = list(map(splitter, inp.split(" ")))
-        observation, info = env.step(action)
-        done = info.get("done")
-
-        env.render()
-        if done:
-            env.reset()
+    while not done:
+        if render:
             env.render()
+        player_turn = env._player_turn
+        if player_turn == PLAYER_1:
+            player = learning_agent
+        else:
+            player = machine_agent
+        action = player.get_action(state)
+        next_state, reward, done, _, info = env.step(action)
+        player.update(state, action, reward, done, next_state)
+            
+        turn += 1
+        if player_turn == PLAYER_1:
+            rw += reward
+        state = next_state
+    
+    if render:
+        env.render()
+    won = info.get("player_1_points") > info.get("player_2_points")
+    return rw, won, turn
 
 
-def save_q(q_file, q_value_function: BoardSaver):
+def play_against_player(board_size, q_file):
+    q_value_function = load_value_function(q_file)
+    env = DotsAndBoxes(board_size)
+    machine_agent = MachineAgent(env, DotsAndBoxesMixerPolicy(q_value_function))
+    user_agent = UserAgent(env)
+    while True:      
+        play_one_game(env, machine_agent, user_agent, render=True)
+            
+
+
+def save_value_function(q_file, q_value_function: BoardSaver):
     with open(q_file, "wb") as handle:
         pickle.dump(q_value_function, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def load_q(q_file) -> BoardSaver:
+def load_value_function(q_file) -> BoardSaver:
     with open(q_file, "rb") as handle:
         training_q_value_function = pickle.load(handle)
     return training_q_value_function
 
 
-def train(board_size, q_file, q_value_function):
-    for e in range(100):
-        logging.info(e)
-        training_q_value_function = load_q(q_file)
-
-        env = DotsAndBoxes(board_size, DotsAndBoxesMixerPolicy(training_q_value_function))
+def train(epochs: int, matches_per_epoch: int, board_size: int, q_file:str):
+    q_value_function = load_value_function(q_file)
+    env = DotsAndBoxes(board_size)
+    greedy_policy = DotsAndBoxesCloseBoxesPolicy(q_value_function=q_value_function)
+    machine_agent = MachineAgent(env=env, policy=greedy_policy)
+    
+    for e in range(epochs):
+        if  q_value_function is None:
+            q_value_function = BoardSaver(board_size)
+        learning_policy = DotsAndBoxesMixerPolicy(q_value_function=q_value_function)
+        learning_agent = EpsilonGreedyAgent(env=env, policy=learning_policy, learning_rate=0.05, initial_epsilon=0.1, epsilon_decay=0.999995, final_epsilon=0.01, gamma=0.95)
+        
         q_value_function = q_learning(
-            env, 2_000, alpha=0.05, gamma=0.95, eps=0.1, epsmin=0.01, eps_decay=0.999995, Q=q_value_function
+            env, matches_per_epoch, machine_agent, learning_agent
         )
-        del training_q_value_function
-        save_q(q_file, q_value_function)
-    return q_value_function
+        
+        save_value_function(q_file, q_value_function)
+        break
 
+    logging.info("finished training")
+
+def policy_against_policy(board_size, games_to_play, agent_1_factory, agent_2_factory):
+    env = DotsAndBoxes(board_size)
+    agent_1 = agent_1_factory(env)
+    agent_2 = agent_2_factory(env)
+    reward = 0
+    won = 0
+    logging.info(f"start policy vs policy")
+    for _ in range(games_to_play):
+        game_rw, game_won, turn = play_one_game(env, agent_1, agent_2)        
+        game_rw += game_rw
+        won += int(game_won)
+    logging.info(f"[{type(agent_2).__name__}] won {won/games_to_play:.2%} of the games with an average reward of {reward/games_to_play:.2%} against {[type(agent_1).__name__]}")
+    
 
 if __name__ == "__main__":
 
@@ -167,15 +152,25 @@ if __name__ == "__main__":
     )
 
     board_size = 3
+    epochs = 100
+    matches_per_epoch = 2_000
     q_file = f"q_value_function_{board_size}x{board_size}.pickle"
 
     if not os.path.exists(q_file):
         with open(q_file, "wb") as handle:
             pickle.dump(BoardSaver(board_size), handle, protocol=pickle.HIGHEST_PROTOCOL)
 
-    q_value_function = load_q(q_file)
-    logging.info(len(q_value_function.boards))
-
-    train(board_size, q_file, q_value_function)
-
-    # play_against_player(board_size, q_value_function)
+        
+    train(epochs, matches_per_epoch, board_size, q_file)
+    # epoch = 439600
+    # q_file = f"q_value_function_{board_size}x{board_size}_epoch{epoch}.pickle"
+    # play_against_player(board_size, q_file)
+    # mixer_factory = lambda q_file: DotsAndBoxesMixerPolicy(load_value_function(q_file))
+    # machine_agent_factory = lambda env, q_file: MachineAgent(env=env, policy=mixer_factory(q_file))
+    # for epoch in [312900, 404600, 414900, 430000, 439600]:
+    #     logging.info(f"best solution is {epoch}")
+    #     agent_1_factory = lambda env: machine_agent_factory(env, f"q_value_function_{board_size}x{board_size}.pickle")
+    #     agent_2_factory = lambda env: machine_agent_factory(env, f"q_value_function_{board_size}x{board_size}_epoch{epoch}.pickle")
+    #     games_to_play = 1000
+    #     policy_against_policy(board_size, games_to_play, agent_1_factory, agent_2_factory)
+        

--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,7 @@ def q_learning(
         if e % 100 == 0:
             avg_rw = rw / 100
             avg_won = won / 100
-            average_new_states = sum((key*value for key, value in amount_of_states.items())) / sum(amount_of_states.values())
+            average_new_states = sum((key*value for key, value in amount_of_states.items())) / sum(amount_of_states.values()) if sum(amount_of_states.values()) != 0 else 0
             average_amount_of_turns = sum((key*value for key, value in amount_of_turns.items())) / sum(amount_of_turns.values())
             logging.info(
                 f"episode: {e}, reward rate: {avg_rw:.2f}, avg_won: {avg_won:.2%}. avg_new_states {average_new_states:.2f}. avg_aot {average_amount_of_turns:.2f}"


### PR DESCRIPTION
The idea is to have different agents, and an env that handles interactions with it.
Having multiple agent implementations lets us have a UserAgent, or different RL agents that train different.
It also simplifies how we interact with the game in case we want to train/play against a particular policy/engage two policies against one another.

The only issue right now is that the training/player/winning policy must be placed in the second agent in the play_one_game